### PR TITLE
Create QRCodeLocalImage.podspec

### DIFF
--- a/QRCodeLocalImage.podspec
+++ b/QRCodeLocalImage.podspec
@@ -1,0 +1,21 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = "QRCodeLocalImage"
+  s.version      = package['version']
+  s.summary      = "Lorem Ipsum"
+  s.license      = package['license']
+
+  s.authors      = package['author']
+  s.homepage     = package['repository']['url']
+  s.platform     = :ios, "9.0"
+  s.ios.deployment_target = '9.0'
+  s.tvos.deployment_target = '10.0'
+
+  s.source       = { :git => "https://github.com/remobile/react-native-qrcode-local-image-nodownload.git", :tag => "v#{s.version}" }
+  s.source_files  = "ios/**/*.{h,m}"
+
+  s.dependency 'React'
+end


### PR DESCRIPTION
Solves _"[!] use_native_modules! skipped the react-native dependency '@remobile/react-native-qrcode-local-image'. No podspec file was found."_